### PR TITLE
Updated rend.go to allowing usage while Defensive Stance

### DIFF
--- a/sim/warrior/rend.go
+++ b/sim/warrior/rend.go
@@ -34,7 +34,7 @@ func (warrior *Warrior) RegisterRendSpell(rageThreshold float64, healthThreshold
 		},
 
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return warrior.StanceMatches(BattleStance)
+			return warrior.StanceMatches(BattleStance) || warrior.StanceMatches(DefensiveStance)
 		},
 
 		DamageMultiplier: 1 + 0.1*float64(warrior.Talents.ImprovedRend),


### PR DESCRIPTION
Requires Battle Stance, Defensive Stance. 
Couldn't add Rend into rotation for prot warrior